### PR TITLE
fix possible timing issue when collecting CSTX acks

### DIFF
--- a/cmd/cstx/coordinator/main.go
+++ b/cmd/cstx/coordinator/main.go
@@ -1,7 +1,5 @@
 package main
 
-//  {"data": "alex"}
-
 import (
 	"log"
 
@@ -11,6 +9,7 @@ import (
 
 func main() {
 	h := cmd.GetHandler()
+	h.StartCSTXAcksConsumer()
 
 	transaction, err := h.BeginCSTX(2, 3000)
 	if err != nil {

--- a/cmd/cstx/service1/main.go
+++ b/cmd/cstx/service1/main.go
@@ -16,6 +16,7 @@ const queue = "service1"
 
 func main() {
 	h := cmd.GetHandler()
+	h.StartCSTXAcksConsumer()
 
 	workerTask := rmqworker.WorkerTask{
 		QueueName:      queue,


### PR DESCRIPTION
resolves #116 

* Это была timing issue: координатор подписывался на exchange позже, чем сервис отправлял подтверждение
* По поводу "лишней" очереди: она не лишняя, сервис, который работает с CSTX всегда должен слушать очередь, потому что подтверждение от одного из других сервисов может придти в любой момент (до того как этот сервис получит информацию об этой транзакции).